### PR TITLE
fix: Update node version for release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '18'
       - name: installs plugins
         run: |
           npm install -g lerna


### PR DESCRIPTION
GitHub Actions agora requer Node na versão acima da 18. Isso está impedindo o fluxo de release de novas versões.
https://github.com/ditointernet/go-dito/actions/runs/4024745627/jobs/6917123393