### PR TITLE
fix: fixing panic when type assertion a non-string attribute

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -194,7 +194,7 @@ func getIsTraceSampled(span trace.Span) *bool {
 func buildOtelAttributes(attrs map[LogAttribute]interface{}, prefix string) []attribute.KeyValue {
 	eAttrs := []attribute.KeyValue{}
 	for k, v := range attrs {
-		eAttrs = append(eAttrs, attribute.String(fmt.Sprintf("%s.%s", prefix, k), v.(string)))
+		eAttrs = append(eAttrs, attribute.String(fmt.Sprintf("%s.%s", prefix, k), fmt.Sprintf("%+v", v)))
 	}
 
 	return eAttrs


### PR DESCRIPTION
When trying to use package go-dito/log to log a value whose type is an struct type, the function `buildOtelAttributes` panics. This occurs beacause this function is trying to do a type assertion with a value that is not a string. In case it is not the intended behavior, maybe we can fix that by replacing this type assertion with a call to `fmt.Sprintf`, using the verb `%+v`. This way, string type attributes will still work and struct type attributes will be used as its default string representation (if that rerepresentation is not sufficient, one can override it, defining a String() method, since the `%v` check if type implements the Stringer interface)