### PR TITLE
chore: Revert release command to define --tag-format itself

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,8 @@
       "@semantic-release/release-notes-generator",
       "@semantic-release/github"
     ],
-    "tagFormat": "${LERNA_PACKAGE_NAME}/v${version}"
   },
   "scripts": {
-    "release": "lerna exec --concurrency 1 -- semantic-release"
+    "release": "lerna exec --concurrency 1 -- semantic-release --tag-format='${LERNA_PACKAGE_NAME}/v${version}'"
   }
 }


### PR DESCRIPTION
Lerna env wasn't being found by semantic-release, so we have to explicitly call it with the --tagFormat