### PR TITLE
fix: move logger to front of middleware chain

### DIFF
--- a/http/server.go
+++ b/http/server.go
@@ -75,6 +75,10 @@ func NewServer(in ServerInput) Server {
 		logger:         in.Logger,
 	}
 
+	if in.Logger != nil {
+		server.addRequestLogger()
+	}
+
 	router.Use(
 		slash.Remover(http.StatusMovedPermanently),
 		content.TypeNegotiator(content.JSON),
@@ -83,9 +87,6 @@ func NewServer(in ServerInput) Server {
 
 	server.addCorsMiddleware()
 	server.addRequestIPIntoContext()
-	if in.Logger != nil {
-		server.addRequestLogger()
-	}
 
 	in.Handler(router)
 


### PR DESCRIPTION
Resumo: corrige ordem incorreta entre middleware de tratamento de erro e de log de request.

Atualmente o log é produzido antes do middleware de tratamento de erro processar o erro retornado, emitindo access log incorreto.
A imagem mostra casos em que 403 são retornados para o cliente enquanto são logados como 200.

![image](https://github.com/user-attachments/assets/699f9985-f20a-4ea6-9d63-01ef8f8e3ac6)
