### PR TITLE
fix: Use base github token with correct permissions as per docs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,18 +4,26 @@ on:
   push:
     branches: [main, beta]
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  
 jobs:
   versioning:
     name: Define next release version
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-node@v2
         with:
           node-version: "18"
+
       - name: Install semantic release plugins
         run: npm ci
+
       - name: Define next release versions
         run: npm run release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Como documentado [aqui](https://github.com/semantic-release/github?tab=readme-ov-file#configuration).

Não tenho acesso aos secrets desse projeto para ver como está o secret atual.